### PR TITLE
Python 3.4 & 3.7 support

### DIFF
--- a/docker/armv6l.dockerfile
+++ b/docker/armv6l.dockerfile
@@ -1,5 +1,5 @@
 # List of balena arm images https://www.balena.io/docs/reference/base-images/devicetypes/
-FROM balenalib/raspberry-pi-debian-python:3.5.6-stretch-build
+FROM balenalib/raspberry-pi-debian-python:3.7.3-stretch-build
 
 # Starting directory
 WORKDIR /app

--- a/docker/armv7l.dockerfile
+++ b/docker/armv7l.dockerfile
@@ -1,5 +1,5 @@
 # List of balena arm images https://www.balena.io/docs/reference/base-images/devicetypes/
-FROM balenalib/raspberrypi3-debian-python:3.5.6-stretch-build
+FROM balenalib/raspberrypi3-debian-python:3.7.3-stretch-build
 
 # Starting directory
 WORKDIR /app

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,8 @@ setup (name = 'matrix-lite',
        zip_safe = False,
        install_requires=['colour<1'],
         classifiers=[
-            'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
         ]
        )


### PR DESCRIPTION
Stretch and Buster use 3.5 & 3.7 respectively by default. However I will add python3.6 into a future build (having issues with the Balena Buster Docker Image).